### PR TITLE
Added vertical alignment to R&L side legends

### DIFF
--- a/viz/Apex-Radar/src/index.css
+++ b/viz/Apex-Radar/src/index.css
@@ -13,4 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
+.apexcharts-legend.position-bottom.apexcharts-align-left, .apexcharts-legend.position-top.apexcharts-align-left, .apexcharts-legend.position-right, .apexcharts-legend.position-left{
+    justify-content: center !important;
+}


### PR DESCRIPTION
This PR has fixes to legend alignment.
Legends will now align vertically with the middle of the viz when placed on right and left sides.